### PR TITLE
changing feed to not include others' microposts' reply

### DIFF
--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -21,6 +21,6 @@ class Micropost < ApplicationRecord
   end
 
   def self.replying(id)
-    Micropost.where("reply_to = ?", id).order("created_at ASC")
+    Micropost.where("reply_to = ?", id).order(created_at: :asc)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,8 +77,10 @@ class User < ApplicationRecord
   def feed
     following_ids = "SELECT followed_id FROM relationships
                      WHERE follower_id = :user_id"
-    Micropost.where("user_id IN (#{following_ids})
+    micro = Micropost.where("user_id IN (#{following_ids})
                      OR user_id = :user_id", user_id: id)
+    feed = micro.where(reply_to: 0).or(micro.where(reply_to: id))
+    return feed
   end
 
   def follow(other_user)


### PR DESCRIPTION
 - 参照すべきissue
    - #18 
    - 他者の投稿に対するリプライは投稿に流れてこないようにした。

- 特記すべき事項
   - リプライの時系列をフィードとは逆にしたいが、orderメソッドがうまくいかない。